### PR TITLE
Update deprecated commands of selenium

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -11,6 +11,8 @@ pwd = 'password'
 import selenium
 import selenium.webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
 
 chrome_options = Options()
 chrome_options.add_argument("--headless") #Remove this to see the process
@@ -18,21 +20,21 @@ driver = selenium.webdriver.Chrome(options=chrome_options)
 
 driver.get('https://netaccess.iitm.ac.in/account/login')
 
-rollNo_box = driver.find_element_by_id('username')
+rollNo_box = driver.find_element(By.ID, 'username')
 rollNo_box.send_keys(rollNo)
 
-pwd_box = driver.find_element_by_id('password')
+pwd_box = driver.find_element(By.ID, 'password')
 pwd_box.send_keys(pwd)
 
-login_button = driver.find_element_by_id('submit')
+login_button = driver.find_element(By.ID, 'submit')
 login_button.click()
 
 driver.get('https://netaccess.iitm.ac.in/account/approve')
 
-oneDay = driver.find_element_by_id('radios-1')
+oneDay = driver.find_element(By.ID, 'radios-1')
 oneDay.click()
 
-approve_button = driver.find_element_by_id('approveBtn')
+approve_button = driver.find_element(By.ID, 'approveBtn')
 approve_button.click()
 
 #print("Successfully authenticated")


### PR DESCRIPTION
Replace deprecated function `find_element_by_id("foo")` of selenium with `find_element(By.ID, "foo")`. 
This prevents the deprecation warning from being printed too.

See [stackoverflow post](https://stackoverflow.com/a/69875984/5331004) for reference.